### PR TITLE
add windows build support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,19 @@ AM_INIT_AUTOMAKE()
 AC_PROG_CC
 AC_CHECK_HEADER([getopt.h],
     [AC_DEFINE([HAVE_GETOPT_H], 1, [Define to 1 if you have <getopt.h>.])],
-		[AC_MSG_ERROR([utftex needs getopt support to run. Please install it.])])
+        [AC_MSG_ERROR([utftex needs getopt support to run. Please install it.])])
+AC_MSG_CHECKING([if libtool needs -no-undefined flag to build shared libraries])
+case "$host_os" in
+  cygwin*|msys*|mingw*)
+    ## Add in the -no-undefined flag to LDFLAGS for libtool.
+    AC_MSG_RESULT([yes])
+    LDFLAGS="$LDFLAGS -no-undefined"
+    ;;
+  *)
+    ## Don't add in anything.
+    AC_MSG_RESULT([no])
+    ;;
+esac
 AC_DEFINE([UTFTEXVERSION], ["1.11"], [utftex version string])
 AC_CONFIG_SRCDIR([src/boxes.c])
 AC_CONFIG_HEADERS([src/config.h])


### PR DESCRIPTION
Adding this lines to the configure script allows compiling on Windows. What I want to do is to do a wrapper for the [Julia Language](https://www.julialang.org), for use in the package [Latexify.jl](https://github.com/korsbo/Latexify.jl). There is at least one more thing that I need to add, which is a `texfree` function to call `free` on output results, but that I'll do on another PR.