### PR TITLE
add `texfree` to symbols exported

### DIFF
--- a/src/texprintfsymbols
+++ b/src/texprintfsymbols
@@ -9,5 +9,6 @@ ftexprintf
 texboxtree
 texlistsymbols
 texerrors
+texfree
 SetStyleASCII
 SetStyleUNICODE


### PR DESCRIPTION
I just noticed that it needs to be in this list texfree for it to be marked properly on the shared library.