### PR TITLE
bugfixes for src/Makefile.am

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -7,8 +7,8 @@ libtexprintf_la_SOURCES = boxes.c  drawbox.c  texprintf.c parser.c lexer.c boxes
 nodist_libtexprintf_la_SOURCES = errorflags.h errormessages.h
 CLEANFILES = errorflags.h errormessages.h
 libtexprintf_la_LIBADD = libstringutils.la
-libtexprintf_la_LDFLAGS = -export-symbols ${srcdir}/texprintfsymbols -version-info 1:0:0 
-man3_MANS = texprintf.3 
+libtexprintf_la_LDFLAGS = -export-symbols ${srcdir}/texprintfsymbols -version-info 1:0:0
+man3_MANS = texprintf.3
 include_HEADERS = texprintf.h
 
 # -- libstringutils/Makefile.am --
@@ -17,16 +17,16 @@ libstringutils_la_SOURCES = stringutils.c
 
 
 bin_PROGRAMS = utftex utfstringinfo
-utftex_SOURCES = main.c testfonts.c testfonts.h
-utftex_LDADD = libtexprintf.la boxes.o error.o stringutils.o drawbox.o lexer.o parser.o
+utftex_SOURCES = main.c testfonts.c testfonts.h boxes.c error.c stringutils.c drawbox.c lexer.c parser.c
+utftex_LDADD = libtexprintf.la
+utftex_CFLAGS = $(AM_CFLAGS) # see https://www.gnu.org/software/automake/manual/html_node/Objects-created-both-with-libtool-and-without.html
 utfstringinfo_SOURCES = stringutils.h unicodeblocks.h utf2unicode.c parsedef.h
 utfstringinfo_LDADD = libstringutils.la
-man1_MANS = utftex.1 utfstringinfo.1 
-EXTRA_DIST = utftex.1 utfstringinfo.1
+man1_MANS = utftex.1 utfstringinfo.1
 
+EXTRA_DIST = utftex.1 utfstringinfo.1 gen_errorflags.sh
 
-BUILT_SOURCES = errorflags.h gen_errorflags.sh
+BUILT_SOURCES = errorflags.h
 
 errorflags.h errormessages.h: gen_errorflags.sh boxes.c drawbox.c lexer.c parser.c
 	${SHELL} ${srcdir}/gen_errorflags.sh ${srcdir}/boxes.c ${srcdir}/drawbox.c ${srcdir}/lexer.c ${srcdir}/parser.c
-


### PR DESCRIPTION
This PR fixes a race condition we noticed in https://github.com/JuliaPackaging/Yggdrasil/pull/6778: if you 
```sh
make clean && rm -rf src/.deps && make -j16
```
you frequently get an error like:
```
mv -f .deps/lexer.Tpo .deps/lexer.Po
mv -f .deps/lexer.Tpo .deps/lexer.Plo
mv: rename .deps/lexer.Tpo to .deps/lexer.Plo: No such file or directory
```
which is clearly a race condition (trying to move the same file twice).

The problem is that you were adding `.o` files manually to `utftex_LDADD` via:
```
utftex_LDADD = libtexprintf.la boxes.o error.o stringutils.o drawbox.o lexer.o parser.o
```
(in order to call unexported symbols from these files, apparently?).  However, the right way to add the same source file to both a library and an executable is described in [this section of the automake manual](https://www.gnu.org/software/automake/manual/html_node/Objects-created-both-with-libtool-and-without.html).

A separate problem I noticed is that you had `BUILT_SOURCES = errorflags.h gen_errorflags.sh`, but `gen_errorflags.sh` is not actually a "built source" (i.e. it is not *generated* by the Makefile).   This causes a problem because if you do `make maintainer-clean` it will remove the `src/gen_errorflags.sh` file.  Instead, this file should be added to `EXTRA_DIST` to ensure that it is included in the tarball.

PS. There are a few extraneous whitespace changes in this PR because my editor removes whitespace at the end of lines.