### PR TITLE
add non-printf texstring(str)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,5 @@
 SUBDIRS = src
-TESTS=runtest.sh testfont.sh testascii.sh
+TESTS=runtest.sh testfont.sh testascii.sh testsprintf.sh
 EXTRA_DIST = runtest.sh testfont.sh test/eq1.tex test/eq2.tex test/eq3.tex test/eq4.tex test/eq5.tex \
 			 test/eq6.tex test/eq7.tex test/eq8.tex test/eq9.tex test/eq10.tex test/eq11.tex test/eq12.tex \
 			 test/eq13.tex test/eq14.tex test/eq15.tex test/eq16.tex test/eq17.tex test/eq18.tex  \

--- a/runtest.sh
+++ b/runtest.sh
@@ -1,26 +1,31 @@
 #!/bin/bash
 cd test
 f=0;
+opt=""
+fopt=""
 if [ "$1" == "ASCII" ]
-then 
+then
 	opt="-A"
+	fopt="-A"
 	shift
-else
-	opt=""
+elif [ "$1" == "SPRINTF" ]
+then
+	opt="-S"
+	shift
 fi
 
 if [ "$1" == "ref" ]
 then
 	for i in *.tex
 	do
-		echo "$i" -- ${i%%.tex}$opt".ref"
-		cat "$i"|grep -E '^[^%]' | utftex $opt > ${i%%.tex}$opt".ref"
+		echo "$i" -- ${i%%.tex}$fopt".ref"
+		cat "$i"|grep -E '^[^%]' | utftex $opt > ${i%%.tex}$fopt".ref"
 	done
 else
 	for i in *.tex
 	do
 		cat "$i"|grep -E '^[^%]' | utftex $opt > tmp
-		if ! cmp -s ${i%%.tex}$opt".ref" tmp
+		if ! cmp -s ${i%%.tex}$fopt".ref" tmp
 		then
 			echo FAIL: "$i"
 			mv tmp ${i%%.tex}$opt".new"
@@ -30,8 +35,8 @@ else
 		fi
 	done
 	rm tmp
-	
-fi	
+
+fi
 if [ "$f" -gt 0 ]
 then
 	exit  1

--- a/src/main.c
+++ b/src/main.c
@@ -15,10 +15,11 @@ int main(int argc, char **argv)
 	int i, c;
 	int printsource=0;
 	int boxtree=0;
+	int test_stexprintf=0;
 	int done=0;
 	char *font=NULL;
 #ifdef __MINGW32__
-	UINT oldcp = GetConsoleOutputCP();	
+	UINT oldcp = GetConsoleOutputCP();
 	SetConsoleOutputCP(CP_UTF8);
 #endif
 	while (1)
@@ -34,24 +35,25 @@ int main(int argc, char **argv)
 			{"default-font",required_argument, 0, 'F'},
 			{"box-tree",          no_argument, 0, 'B'},
 			{"test-fonts",  required_argument, 0, 't'},
+			{"test-stexprintf",  required_argument, 0, 'S'},
 			{"ascii",             no_argument, 0, 'A'},
 			{0, 0, 0, 0}
 		};
 		int option_index = 0;
-		c = getopt_long (argc, argv, "l:sviw:f:F:BtA",long_options, &option_index);
-		
+		c = getopt_long (argc, argv, "l:sviw:f:F:BtSA",long_options, &option_index);
+
 		if (c == -1)
 			break;
-			
+
 		switch (c)
 		{
 			case 'l':
 				if (!optarg)
 				{
 					fprintf(stderr, "Error: --line-width requires an integer as argument\n");
-					return 1;	
+					return 1;
 				}
-				
+
 				TEXPRINTF_LW=atoi(optarg);
 				break;
 			case 's':
@@ -71,32 +73,32 @@ int main(int argc, char **argv)
 				printf("This is utftex version %s\nPowered by %s\n", UTFTEXVERSION, PACKAGE_STRING);
 				done++;
 				break;
-			case 'i':				
+			case 'i':
 				printsource=1;
 				break;
 			case 'w':
 				if (!optarg)
 				{
 					fprintf(stderr, "Error: --wchar-width requires the number of spaces for a wide character (1 or 2)\n");
-					return 1;	
+					return 1;
 				}
-				
+
 				TEXPRINTF_WCW=atoi(optarg);
 				break;
 			case 'f':
 				if (!optarg)
 				{
 					fprintf(stderr, "Error: --fchar-width requires the number of spaces for a full width character (1 or 2)\n");
-					return 1;	
+					return 1;
 				}
-				
+
 				TEXPRINTF_FCW=atoi(optarg);
 				break;
 			case 'F':
 				if (!optarg)
 				{
 					fprintf(stderr, "Error: --default-font requires the default font style name\n");
-					return 1;	
+					return 1;
 				}
 				font=malloc((strlen(optarg)+1)*sizeof(char));
 				strcpy(font, optarg);
@@ -104,6 +106,9 @@ int main(int argc, char **argv)
 				break;
 			case 'B':
 				boxtree=1;
+				break;
+			case 'S':
+				test_stexprintf=1;
 				break;
 			case 'A':
 				SetStyleASCII();
@@ -119,8 +124,14 @@ int main(int argc, char **argv)
       while (optind < argc)
       {
 			if (printsource)
-				printf("%s\n",argv[optind]);			
-			texprintf("%s\n",argv[optind]);
+				printf("%s\n",argv[optind]);
+			if (test_stexprintf) {
+				char *str = stexprintf("%s\n",argv[optind]);
+				puts(str);
+				texfree(str);
+			}
+			else
+				texprintf("%s\n",argv[optind]);
 			texerrors();
 			if (boxtree)
 				texboxtree("%s\n",argv[optind]);
@@ -128,7 +139,7 @@ int main(int argc, char **argv)
 			optind++;
 		}
 	}
-	
+
 	if (!done)
 	{
 		char *buffer;
@@ -147,13 +158,19 @@ int main(int argc, char **argv)
 		}
 		buffer[i]='\0';
 		if (printsource)
-			printf("%s\n",buffer);			
-		texprintf("%s\n",buffer);
+			printf("%s\n",buffer);
+		if (test_stexprintf) {
+			char *str = stexprintf("%s\n",buffer);
+			puts(str);
+			texfree(str);
+		}
+		else
+			texprintf("%s\n",buffer);
 		texerrors();
 		if (boxtree)
 			texboxtree("%s\n",argv[optind]);
 	}
-	
+
 #ifdef __MINGW32__
 	SetConsoleOutputCP(oldcp);
 #endif

--- a/src/texprintf.c
+++ b/src/texprintf.c
@@ -22,7 +22,7 @@ int texprintf(const char *format, ...)
    	char *str;
    	int Na=255, np;
 	box root;
-   	
+
 	ResetErrors();
 	FCSPACES=TEXPRINTF_FCW;
 	WCSPACES=TEXPRINTF_WCW;
@@ -36,7 +36,7 @@ int texprintf(const char *format, ...)
 		fprintf(stderr,"Error: TEXPRINTF_FCW out of range, wide characters can occupy either 1 or 2 character spaces\n");
 		exit(1);
 	}
-	
+
    	str=malloc(Na*sizeof(char));
    	va_start (ap, format);
    	np=vsnprintf(str, Na*sizeof(char), format, ap);
@@ -47,7 +47,7 @@ int texprintf(const char *format, ...)
 		va_start (ap, format);
 		np=vsnprintf(str, Na*sizeof(char), format, ap);
 	}
-	
+
 	root=ParseString(str, TEXPRINTF_LW, TEXPRINTF_FONT);
 	BoxPos(&root);
 	np=PrintBox(&root);
@@ -57,15 +57,11 @@ int texprintf(const char *format, ...)
 	return np;
 }
 
-
-char * stexprintf(const char *format, ...)
+char * texstring(const char *str)
 {
-   	va_list ap;
-   	char *res;
-   	char *str;
-   	int Na=255, np;
 	box root;
-   	
+	char *res;
+
 	ResetErrors();
 	FCSPACES=TEXPRINTF_FCW;
 	WCSPACES=TEXPRINTF_WCW;
@@ -79,7 +75,24 @@ char * stexprintf(const char *format, ...)
 		fprintf(stderr,"Error: TEXPRINTF_FCW out of range, wide characters can occupy either 1 or 2 character spaces\n");
 		exit(1);
 	}
-   	
+
+	root=ParseString(str, TEXPRINTF_LW, TEXPRINTF_FONT);
+	BoxPos(&root);
+	res=DrawBox(&root);
+	FreeBox(&root);
+	TEXPRINTF_ERR=ERRORSTATE;
+
+	return res;
+}
+
+
+char * stexprintf(const char *format, ...)
+{
+   	va_list ap;
+   	char *res;
+   	char *str;
+   	int Na=255, np;
+
    	str=malloc(Na*sizeof(char));
    	va_start (ap, format);
    	np=vsnprintf(str, Na*sizeof(char), format, ap);
@@ -90,14 +103,9 @@ char * stexprintf(const char *format, ...)
 		va_start (ap, format);
 		np=vsnprintf(str, Na*sizeof(char), format, ap);
 	}
-	
-	root=ParseString(str, TEXPRINTF_LW, TEXPRINTF_FONT);
-	BoxPos(&root);
-	res=DrawBox(&root);
-	FreeBox(&root);
-	free(str);	
-	TEXPRINTF_ERR=ERRORSTATE;
 
+	res = texstring(str);
+	free(str);
 	return res;
 }
 
@@ -113,7 +121,7 @@ int ftexprintf(FILE *f, const char *format, ...)
    	char *str;
    	int Na=255, np;
 	box root;
-   	
+
 	ResetErrors();
 	FCSPACES=TEXPRINTF_FCW;
 	WCSPACES=TEXPRINTF_WCW;
@@ -127,7 +135,7 @@ int ftexprintf(FILE *f, const char *format, ...)
 		fprintf(stderr,"Error: TEXPRINTF_FCW out of range, wide characters can occupy either 1 or 2 character spaces\n");
 		exit(1);
 	}
-   	
+
    	str=malloc(Na*sizeof(char));
    	va_start (ap, format);
    	np=vsnprintf(str, Na*sizeof(char), format, ap);
@@ -138,7 +146,7 @@ int ftexprintf(FILE *f, const char *format, ...)
 		va_start (ap, format);
 		np=vsnprintf(str, Na*sizeof(char), format, ap);
 	}
-	
+
 	root=ParseString(str, TEXPRINTF_LW, TEXPRINTF_FONT);
 	BoxPos(&root);
 	res=DrawBox(&root);
@@ -146,7 +154,7 @@ int ftexprintf(FILE *f, const char *format, ...)
 	free(str);
 	np=strlen(res);
 	fprintf(f,"%s",res);
-	free(res);	
+	free(res);
 	TEXPRINTF_ERR=ERRORSTATE;
 
 	return np;
@@ -158,7 +166,7 @@ void texboxtree(const char *format, ...)
    	char *str;
    	int Na=255, np;
 	box root;
-   	
+
 	ResetErrors();
 	FCSPACES=TEXPRINTF_FCW;
 	WCSPACES=TEXPRINTF_WCW;
@@ -172,7 +180,7 @@ void texboxtree(const char *format, ...)
 		fprintf(stderr,"Error: TEXPRINTF_FCW out of range, wide characters can occupy either 1 or 2 character spaces\n");
 		exit(1);
 	}
-	
+
    	str=malloc(Na*sizeof(char));
    	va_start (ap, format);
    	np=vsnprintf(str, Na*sizeof(char), format, ap);
@@ -183,7 +191,7 @@ void texboxtree(const char *format, ...)
 		va_start (ap, format);
 		np=vsnprintf(str, Na*sizeof(char), format, ap);
 	}
-	
+
 	root=ParseString(str, TEXPRINTF_LW, TEXPRINTF_FONT);
 	BoxPos(&root);
 	DrawBoxTree(&root);

--- a/src/texprintf.h
+++ b/src/texprintf.h
@@ -21,6 +21,7 @@ extern int TEXPRINTF_WCW;								/* wide character width */
 extern int TEXPRINTF_ERR;
 int texprintf(const char *format, ...);					/* prints to stdout */
 char * stexprintf(const char *format, ...);				/* prints to string */
+char * texstring(const char *str);                      /* stextprintf, but no printf formatting */
 void texfree(void *ptr);								/* free memory from results */
 int ftexprintf(FILE *f, const char *format, ...);		/* prints to file */
 void texboxtree(const char *format, ...);				/* print the box-tree, for debugging purposes */

--- a/testsprintf.sh
+++ b/testsprintf.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+./runtest.sh SPRINTF


### PR DESCRIPTION
This adds a new API function `char *texstring(const char *str)`, which is similar to `stexprintf` but doesn't do any `printf` formatting.   (`stexprintf` is refactored to call `texstring`, so there isn't much duplication.)

It is useful to expose this lower-level functionality, e.g. for calling from higher-level languages that have their own `printf`-like functionality (e.g. Python f-strings) that may or may not use the same syntax.   It's not equivalent to simply calling `stexprintf` with no arguments, because then you have to worry about escaping `%` characters.  cc @Suavesito-Olimpiada 

Also added a test script `testsprintf.sh` to test `stexprintf` — that function wasn't previously being tested; this involved adding an `-S` option to `utftex` so that it calls `puts(stexprintf(...))` instead of `texprintf(...)`.

(Will need a rebase/merge once #12 is merged.)