### PR TITLE
fix CI and add CI badge to README.md

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,11 +7,7 @@ on:
     tags: '*'
 jobs:
   build:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macOS-latest]
-    runs-on: ${{ matrix.os }}
-    name: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 libtexprintf & utftex
 =====================
+[![CI](https://github.com/bartp5/libtexprintf/workflows/CI/badge.svg)](https://github.com/bartp5/libtexprintf/actions?query=workflow%3ACI)
 
 The utftex program and underlying libtexprintf library provide tools to
 pretty print math in mono-space fonts, using a tex-like syntax. It 


### PR DESCRIPTION
This adds a "badge" icon with the CI status to the README.

Also changes CI to only run on Ubuntu.  To run it on MacOS (or MinGW) would be nice too, but we'll need to update the script to install autotools on those systems.  (Currently `autogen.sh` fails on the github MacOS host because of missing autotools software.)