### PR TITLE
Add WASM Node usage docs and ignore generated artifacts

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,81 @@
+name: Publish npm (Trusted Publishing)
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      - name: Setup Emscripten
+        uses: mymindstorm/setup-emsdk@v14
+        with:
+          version: latest
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y autoconf automake libtool make
+
+      - name: Build WASM
+        run: |
+          sh autogen.sh
+
+          emconfigure ./configure \
+            --host=wasm32-unknown-emscripten \
+            --disable-shared \
+            --enable-static \
+            CFLAGS='-O3' \
+            LDFLAGS='-s STANDALONE_WASM=1'
+
+          emmake make -j"$(nproc)"
+
+          emcc -O3 -s STANDALONE_WASM=1 \
+            -Wl,--no-entry \
+            -Wl,--export=texstring \
+            -Wl,--export=texfree \
+            -Wl,--export=malloc \
+            -Wl,--export=free \
+            -o libtexprintf.wasm \
+            src/.libs/libtexprintf.a
+
+      - name: Run Node tests
+        run: node --test examples/libtexprintf.test.js
+
+      - name: Prepare npm package
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+$ ]]; then
+            echo "Release tag must match vX.Y (example: v1.2)." >&2
+            exit 1
+          fi
+          VERSION="${RELEASE_TAG#v}.0"
+
+          rm -rf npm-dist
+          mkdir -p npm-dist
+
+          cp examples/libtexprintf.js npm-dist/libtexprintf.js
+          cp libtexprintf.wasm npm-dist/libtexprintf.wasm
+          cp README.md npm-dist/README.md
+          cp COPYING npm-dist/LICENSE
+          cp examples/npm-package.json npm-dist/package.json
+
+          npm --prefix npm-dist version "$VERSION" --no-git-tag-version --allow-same-version
+
+      - name: Publish to npm (OIDC)
+        run: npm publish ./npm-dist --access public --provenance

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ missing
 m4/
 stamp-h1
 test-driver
+npm-dist/

--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,12 @@ src/utfstringinfo
 src/utftex
 src/errorflags.h
 src/errormessages.h
+src/texprintfsymbols
 
 *.o
 *.lo
 *.la
+*.wasm
 
 test/*.new
 *.log

--- a/README.md
+++ b/README.md
@@ -185,7 +185,34 @@ Questions One Might Ask (QOMA)
 
 WASM (Node.js)
 --------------
-Build `libtexprintf.wasm` as a standalone WASM library and export `texstring`:
+Install from npm (recommended):
+
+```sh
+npm install libtexprintf
+```
+
+Usage (ESM):
+
+```js
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { WASI } from "node:wasi";
+import { createRender } from "libtexprintf";
+
+const require = createRequire(import.meta.url);
+const wasmPath = require.resolve("libtexprintf/libtexprintf.wasm");
+const wasmBytes = readFileSync(wasmPath);
+
+const wasi = new WASI({ version: "preview1" });
+const { instance } = await WebAssembly.instantiate(wasmBytes, {
+  wasi_snapshot_preview1: wasi.wasiImport,
+});
+
+const render = createRender(instance);
+console.log(render("\\frac{\\alpha}{\\beta+x}"));
+```
+
+Build from source (`libtexprintf.wasm` as standalone WASM with `texstring` export):
 
 ```sh
 emconfigure ./configure \
@@ -204,41 +231,3 @@ emcc -O3 -s STANDALONE_WASM=1 \
   -o libtexprintf.wasm \
   src/.libs/libtexprintf.a
 ```
-
-<details>
-<summary>JavaScript glue code (Node.js)</summary>
-
-```js
-import fs from "node:fs";
-import { WASI } from "node:wasi";
-
-const enc = new TextEncoder();
-const dec = new TextDecoder();
-export async function createRenderer(wasmPath = "./libtexprintf.wasm") {
-  const wasi = new WASI({ version: "preview1" });
-  const imports = { wasi_snapshot_preview1: wasi.wasiImport };
-  const bytes = fs.readFileSync(wasmPath);
-  const { instance } = await WebAssembly.instantiate(bytes, imports);
-
-  return function render(latex) {
-    const bytes = enc.encode(latex + "\0");
-    const inPtr = instance.exports.malloc(bytes.length);
-    new Uint8Array(instance.exports.memory.buffer, inPtr, bytes.length).set(bytes);
-    const outPtr = instance.exports.texstring(inPtr);
-    instance.exports.free(inPtr);
-
-    const mem = new Uint8Array(instance.exports.memory.buffer);
-    let end = outPtr;
-    while (mem[end] !== 0) end++;
-    const out = dec.decode(mem.subarray(outPtr, end));
-    instance.exports.texfree(outPtr);
-    return out;
-  };
-}
-
-// Usage:
-// const render = await createRenderer("./libtexprintf.wasm");
-// console.log(render("\\frac{\\alpha}{\\beta+x}"));
-```
-
-</details>

--- a/README.md
+++ b/README.md
@@ -183,3 +183,62 @@ Questions One Might Ask (QOMA)
 ```	     
 
 
+WASM (Node.js)
+--------------
+Build `libtexprintf.wasm` as a standalone WASM library and export `texstring`:
+
+```sh
+emconfigure ./configure \
+  --host=wasm32-unknown-emscripten \
+  --disable-shared \
+  --enable-static \
+  CFLAGS='-O3' LDFLAGS='-s STANDALONE_WASM=1'
+emmake make -j4
+
+emcc -O3 -s STANDALONE_WASM=1 \
+  -Wl,--no-entry \
+  -Wl,--export=texstring \
+  -Wl,--export=texfree \
+  -Wl,--export=malloc \
+  -Wl,--export=free \
+  -o libtexprintf.wasm \
+  src/.libs/libtexprintf.a
+```
+
+<details>
+<summary>JavaScript glue code (Node.js)</summary>
+
+```js
+import fs from "node:fs";
+import { WASI } from "node:wasi";
+
+const enc = new TextEncoder();
+const dec = new TextDecoder();
+export async function createRenderer(wasmPath = "./libtexprintf.wasm") {
+  const wasi = new WASI({ version: "preview1" });
+  const imports = { wasi_snapshot_preview1: wasi.wasiImport };
+  const bytes = fs.readFileSync(wasmPath);
+  const { instance } = await WebAssembly.instantiate(bytes, imports);
+
+  return function render(latex) {
+    const bytes = enc.encode(latex + "\0");
+    const inPtr = instance.exports.malloc(bytes.length);
+    new Uint8Array(instance.exports.memory.buffer, inPtr, bytes.length).set(bytes);
+    const outPtr = instance.exports.texstring(inPtr);
+    instance.exports.free(inPtr);
+
+    const mem = new Uint8Array(instance.exports.memory.buffer);
+    let end = outPtr;
+    while (mem[end] !== 0) end++;
+    const out = dec.decode(mem.subarray(outPtr, end));
+    instance.exports.texfree(outPtr);
+    return out;
+  };
+}
+
+// Usage:
+// const render = await createRenderer("./libtexprintf.wasm");
+// console.log(render("\\frac{\\alpha}{\\beta+x}"));
+```
+
+</details>

--- a/examples/libtexprintf.js
+++ b/examples/libtexprintf.js
@@ -1,0 +1,56 @@
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+/**
+ * @typedef {object} TexprintfExports
+ * @property {WebAssembly.Memory} memory
+ * @property {(size: number) => number} malloc
+ * @property {(ptr: number) => void} free
+ * @property {(inputPtr: number) => number} texstring
+ * @property {(outputPtr: number) => void} texfree
+ */
+
+/**
+ * @typedef {WebAssembly.Instance & { exports: TexprintfExports }} TexprintfInstance
+ */
+
+/**
+ * Create a renderer from an already instantiated libtexprintf WASM instance.
+ *
+ * @param {TexprintfInstance} instance
+ * @returns {(latex: string) => string}
+ */
+export function createRender(instance) {
+  if (!(instance instanceof WebAssembly.Instance)) {
+    throw new TypeError("createRender expects a WebAssembly.Instance");
+  }
+
+  /** @type {TexprintfExports} */
+  const { memory, malloc, free, texstring, texfree } = instance.exports;
+  if (!memory || !malloc || !free || !texstring || !texfree) {
+    throw new Error("WASM module is missing one or more required exports");
+  }
+
+  return function render(latex) {
+    const input = encoder.encode(String(latex) + "\0");
+    const inputPtr = malloc(input.length);
+
+    try {
+      new Uint8Array(memory.buffer, inputPtr, input.length).set(input);
+      const outputPtr = texstring(inputPtr);
+
+      try {
+        const mem = new Uint8Array(memory.buffer);
+        let end = outputPtr;
+        while (mem[end] !== 0) {
+          end += 1;
+        }
+        return decoder.decode(mem.subarray(outputPtr, end));
+      } finally {
+        texfree(outputPtr);
+      }
+    } finally {
+      free(inputPtr);
+    }
+  };
+}

--- a/examples/libtexprintf.test.js
+++ b/examples/libtexprintf.test.js
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+import { createRender } from "./libtexprintf.js";
+
+async function createInstance() {
+  const wasmBytes = await readFile(new URL("../libtexprintf.wasm", import.meta.url));
+  const imports = {
+    wasi_snapshot_preview1: {
+      proc_exit(code) {
+        throw new Error(`WASM requested proc_exit(${code})`);
+      },
+      fd_close() {
+        return 0;
+      },
+      fd_write() {
+        return 0;
+      },
+      fd_seek() {
+        return 0;
+      },
+    },
+  };
+  const { instance } = await WebAssembly.instantiate(wasmBytes, imports);
+  return instance;
+}
+
+test("createRender rejects non-WebAssembly instances", () => {
+  assert.throws(
+    () => createRender({}),
+    /createRender expects a WebAssembly\.Instance/
+  );
+});
+
+test("render fraction", async () => {
+  const instance = await createInstance();
+  const render = createRender(instance);
+  assert.equal(render("\\frac{\\alpha}{\\beta+x}"), " α\n───\nβ+x");
+});

--- a/examples/npm-package.json
+++ b/examples/npm-package.json
@@ -1,0 +1,16 @@
+{
+  "name": "libtexprintf-wasm",
+  "version": "0.0.0",
+  "type": "module",
+  "exports": {
+    ".": "./libtexprintf.js",
+    "./libtexprintf.wasm": "./libtexprintf.wasm"
+  },
+  "files": [
+    "libtexprintf.js",
+    "libtexprintf.wasm",
+    "README.md",
+    "LICENSE"
+  ],
+  "license": "GPL-3.0-or-later"
+}


### PR DESCRIPTION
Hello. Thank you for the great project! I added a simple WASM + Node.js guide to the README so people can build libtexprintf.wasm and use it directly from JavaScript without extra C wrapper files. I tested the flow end-to-end and confirmed rendering works (including on Node 22 and Bun). Thanks!